### PR TITLE
fix(ci) Fix segmentation fault when building image for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.23.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.5 AS builder
+
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -11,7 +13,7 @@ COPY cmd/observability-operator/main.go cmd/observability-operator/main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager cmd/observability-operator/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -a -o manager cmd/observability-operator/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
# Context

CI is failing with this error:
```
[linux/arm64 builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager cmd/observability-operator/main.go
#24 297.6 google.golang.org/protobuf/reflect/protoregistry: /usr/local/go/pkg/tool/linux_arm64/compile: signal: segmentation fault (core dumped)
#24 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager cmd/observability-operator/main.go" did not complete successfully: exit code: 1
```

# Changes in this PR

This PR attempts to fix this by using the `BUILDPLATFORM` and `TARGETARCH` arguments provided by Docker buildx[^1].


[^1]: https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application